### PR TITLE
fix VERSION setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,17 @@
 
 from setuptools import setup
 
-try:
-    from xleditor import VERSION
-except Exception as e:
-    VERSION = ''
+""" 
+从 xleditor import VERSION 可能因为其他代码导致错误, 比如因为安装顺序的关系, xlrd 还没有安装好, 
+这时候 xleditor 还不能正常使用但是 setup 应该不被影响
+VERSION 应该在这里定义
+"""
+# try:
+#     from xleditor import VERSION
+# except Exception as e:
+#     VERSION = ''
 
+VERSION = '1.0.2'
 
 setup(
     name='xleditor',


### PR DESCRIPTION
python 3.8 安装 packages 的顺序有点不同, 从 import xleditor 的时候可能会因为 xlrd 还没有安装导致出错, 这时候 setup 里面的 VERSION 就成了空值